### PR TITLE
Add information to catalog

### DIFF
--- a/apicurio/sw/apicurito.yaml
+++ b/apicurio/sw/apicurito.yaml
@@ -4,10 +4,23 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: Apicurito
+  description: Apicurito is basically the OpenAPI editor found in Studio and repackaged as a simple standalone web application. It has no back-end component at all, which makes it incredibly easy to package, deploy, and use. However, the trade-off is that it only supports the core visual editing experience found in Studio, without the collaboration, persistence, and integration with external systems.
   links:
     - url: https://www.apicur.io/apicurito/
       title: Page
       icon: dashboard
+    - url: https://www.apicur.io/apicurito/download/
+      title: Download
+      icon: web
+    - url: https://github.com/apicurio/apicurito/issues
+      title: Issue Tracker
+      icon: web
+      - url: https://hub.docker.com/search?q=apicurio%2Fapicurito&type=image
+      title: Docker Images
+      icon: web
+    - url: https://www.apicur.io/apicurito/pwa/
+      title: Try Live
+      icon: web
   annotations:
     backstage.io/source-location: url:https://github.com/Apicurio/apicurito
 spec:

--- a/apicurio/sw/datamodels.yaml
+++ b/apicurio/sw/datamodels.yaml
@@ -4,10 +4,20 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: DataModels
+  description: The Apicurio Data Models library is a Java and Typescript compatible library that provides reading, writing, analysis, modification, and validation of OpenAPI and AsyncAPI documents. Use this library if you need to support either OpenAPI or AsyncAPI specifications in your own projects.
   links:
     - url: https://www.apicur.io/datamodels/
       title: Page
       icon: dashboard
+    - url: https://www.apicur.io/datamodels/usagejava/
+      title: Usage (Java)
+      icon: web
+    - url: https://www.apicur.io/datamodels/usagets/
+      title: Usage (Typescript)
+      icon: web
+    - url: https://github.com/apicurio/apicurio-data-models/issues
+      title: Issue Tracker
+      icon: web
   annotations:
     backstage.io/source-location: url:https://github.com/Apicurio/apicurio-data-models
 spec:

--- a/apicurio/sw/registry.yaml
+++ b/apicurio/sw/registry.yaml
@@ -4,10 +4,26 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: ApicurioRegistry
+  description: In the context of Apicurio, a registry is a runtime system (server) that stores a specific set of artifacts (files). At its core, a registry provides the ability to add, update, and remove the artifacts from the store, typically via a remote API of some kind (often a REST API).
   links:
     - url: https://www.apicur.io/registry/
-      title: Page
+      title: Website
       icon: dashboard
+    - url: https://www.apicur.io/registry/try-live/
+      title: Try Live
+      icon: web
+    - url: https://www.apicur.io/registry/download/
+      title: Download
+      icon: web
+    - url: https://www.apicur.io/registry/docs/apicurio-registry/2.4.x/index.html
+      title: Documentation
+      icon: web
+    - url: https://github.com/apicurio/apicurio-registry/issues
+      title: Issue Tracker
+      icon: web
+    - url: hhttps://hub.docker.com/search?q=apicurio%2Fapicurio-registry&type=image
+      title: Docker Images
+      icon: web
   annotations:
     backstage.io/source-location: url:https://github.com/Apicurio/apicurio-registry
 spec:

--- a/apicurio/sw/studio.yaml
+++ b/apicurio/sw/studio.yaml
@@ -4,10 +4,29 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: ApicurioStudio
+  description: Apicurio Studio is a web based API Design suite, primarily (but not exclusively) built to support design-first REST API development. It provides a way for users to collaboratively and visually design their APIs prior to (or concurrent with) the implementation.
   links:
     - url: https://www.apicur.io/studio/
-      title: Page
+      title: Website
       icon: dashboard
+    - url: https://www.apicur.io/studio/download/
+      title: Download
+      icon: web
+    - url: https://www.apicur.io/studio/docs/
+      title: Documentation
+      icon: web
+    - url: https://www.apicur.io/studio/roadmap/
+      title: Roadmap
+      icon: web
+    - url: https://github.com/apicurio/apicurio-studio/issues
+      title: Issue Tracker
+      icon: web
+    - url: https://hub.docker.com/search?q=apicurio%2Fapicurio-studio&type=image
+      title: Docker Images
+      icon: web
+    - url: https://studio.apicur.io/
+      title: Try Live
+      icon: web
   annotations:
     backstage.io/source-location: url:https://github.com/Apicurio/apicurio-studio
 spec:

--- a/apicurio/sw/systems/downstream.yaml
+++ b/apicurio/sw/systems/downstream.yaml
@@ -4,6 +4,7 @@ apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
   name: downstream
+  description: The downstream system consists of the ServiceRegistry component.
   annotations:
     backstage.io/source-location: url:https://www.redhat.com
 spec:

--- a/apicurio/sw/systems/upstream.yaml
+++ b/apicurio/sw/systems/upstream.yaml
@@ -4,6 +4,7 @@ apiVersion: backstage.io/v1alpha1
 kind: System
 metadata:
   name: upstream
+  description: "The upstream system in Apicurio encompasses several key components: ApicurioRegistry, ApicurioStudio, Apicurito, DataModels and the Website."
   annotations:
     backstage.io/source-location: ""
 spec:

--- a/apicurio/sw/website.yaml
+++ b/apicurio/sw/website.yaml
@@ -4,6 +4,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: Website
+  description: Visit our official website to find our main products such as Apicurio Studio for intuitive API design, Apicurio Registry for API and schema management, Apicurio Data Models for specification-oriented data modeling, and Apicurito, a compact version of our Studio for seamless API editing.
   links:
     - url: https://www.apicur.io
       title: Apicurio Website


### PR DESCRIPTION
Hi Paolo/Andrea,

I've added some descriptions and links to the catalog page. I used the descriptions from apicur.io for most projects as they seemed sufficiently accurate. If you'd prefer us to rewrite these descriptions in our own words, please let us know.

In the 'links' section, I included all the URLs from the official website, except the source code link, as that is already available on each component page. I selected the 'web' icon, but feel free to change it if you think something else would be more appropriate.

I'll keep adding information to the catalog and please let me know if there are any mistakes or misunderstandings.

Regards
